### PR TITLE
moduleのemitにOnlyオプションを使えるようにした

### DIFF
--- a/lib/emitting/ws_emitter.js
+++ b/lib/emitting/ws_emitter.js
@@ -17,12 +17,24 @@ class WsEmitter extends EventEmitter {
 
     let emit = s.emit.bind(s)
 
-    s.emit = function pipingEmit (event, data) {
+    /**
+     * Emit event
+     * @param {string} event - Name of event
+     * @param {Object} data - Event data
+     * @param {Object} [options={}] - Optional settings
+     * @param {string[]} [options.only] - Target caller keys
+     */
+    s.emit = function pipingEmit (event, data, options = {}) {
       if (s.opened) {
+        let { only = null } = options
         let isObject = typeof data === 'object'
         let { payload, meta: types } = isObject ? format(data) : { payload: data }
         let piping = Object.assign({}, defaults, {
-          event, data: payload, module: moduleName, meta: { types }
+          event,
+          data: payload,
+          module: moduleName,
+          meta: { types },
+          only
         })
         socket.emit(PIPE, piping)
       }


### PR DESCRIPTION
Actorに繋いだmoduleからemitする時に、onlyオプションで対象のcallerを絞れるようにした


```javascript
myModule.emit('someEvent', { foo: 'bar' }, {
   only: ['caller01']
})
```